### PR TITLE
don't re-add protocol if it already exists

### DIFF
--- a/src/__tests__/tests.ts
+++ b/src/__tests__/tests.ts
@@ -14,6 +14,8 @@ describe("go/link regex", () => {
     ["go/snake_case", true],
     ["go/call-123", true],
     ["go/kitchen_sink-123/cool", true],
+    ["to match link w/ protocol https://go/link", true],
+    ["to match link w/ http protocol http://go/link", true],
     // ["go//hello-世界", true], // doesn't work yet
   ]).test(
     'expect "%s" to match? %s',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-export const goLinkRegex = /\bgo\/[_\d\w-/]+/;
+// export const goLinkRegex = /\bgo\/[_\d\w\-/]+/;
+export const goLinkRegex = /\b(https?:\/\/)?go\/[_\d\w\-/]+/;
 
 export const isTextNodeWithGoLink = (n: Node): boolean =>
   n.nodeType === Node.TEXT_NODE && Boolean(n.textContent?.match(goLinkRegex));
@@ -20,7 +21,7 @@ export const parseNextLink = (
 };
 
 export const createLinkTag = (el: Element, goLink: string): Element => {
-  const href = `http://${goLink}`;
+  const href = goLink.startsWith("http") ? goLink : `http://${goLink}`;
   // <a aria-label-position="top" aria-label="http://go/actual-link" rel="noopener" class="external-link" href="http://go/actual-link" target="_blank">go/actual-link</a>
   // this creates it on the parent element we're replacing, so that's probably fine; we keep the reference to it
   return el.createEl("a", {


### PR DESCRIPTION
Fixes #4

@streeter-stripe it now leaves links w/ protocols exactly how they're written:

<img width="479" alt="image" src="https://github.com/user-attachments/assets/8b6421d3-5892-4a89-87a8-765692feb2a9" />

Their linkification is still handled by the plugin, since obisidian doesn't recognize `http://go/link` as a valid url.

I'm printing them exactly as written, but I could also hide the protocol in preview mode. So 

```md
this is a https://go/link
```

would render as 

```md
this is a [go/link](https://go/link-cool)
```

Do you have a preference between the two?